### PR TITLE
swap assertion package with working tests

### DIFF
--- a/aspnet-core/test/AbpCompanyName.AbpProjectName.Tests/AbpCompanyName.AbpProjectName.Tests.csproj
+++ b/aspnet-core/test/AbpCompanyName.AbpProjectName.Tests/AbpCompanyName.AbpProjectName.Tests.csproj
@@ -18,18 +18,18 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="NSubstitute" Version="5.0.0" />
-    <PackageReference Include="Shouldly" Version="4.2.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="NSubstitute" Version="4.3.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Abp.TestBase" Version="8.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.5" />
-    <PackageReference Include="Castle.Core" Version="5.1.1" NoWarn="NU1608;" />
+    <PackageReference Include="Castle.Core" Version="4.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/aspnet-core/test/AbpCompanyName.AbpProjectName.Tests/Sessions/SessionAppServiceTests.cs
+++ b/aspnet-core/test/AbpCompanyName.AbpProjectName.Tests/Sessions/SessionAppServiceTests.cs
@@ -3,7 +3,7 @@
 // Contributions Copyright © 2023 Mesh Systems LLC
 
 using AbpCompanyName.AbpProjectName.Sessions;
-using Shouldly;
+using FluentAssertions;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -13,10 +13,8 @@ namespace AbpCompanyName.AbpProjectName.Tests.Sessions
     {
         private readonly ISessionAppService _sessionAppService;
 
-        public SessionAppServiceTests()
-        {
+        public SessionAppServiceTests() =>
             _sessionAppService = Resolve<ISessionAppService>();
-        }
 
         [MultiTenantFact]
         public async Task Should_Get_Current_User_When_Logged_In_As_Host()
@@ -29,11 +27,11 @@ namespace AbpCompanyName.AbpProjectName.Tests.Sessions
 
             // Assert
             var currentUser = await GetCurrentUserAsync();
-            output.User.ShouldNotBe(null);
-            output.User.Name.ShouldBe(currentUser.Name);
-            output.User.Surname.ShouldBe(currentUser.Surname);
+            output.User.Should().NotBeNull();
+            output.User.Name.Should().Be(currentUser.Name);
+            output.User.Surname.Should().Be(currentUser.Surname);
 
-            output.Tenant.ShouldBe(null);
+            output.Tenant.Should().BeNull();
         }
 
         [Fact]
@@ -46,11 +44,11 @@ namespace AbpCompanyName.AbpProjectName.Tests.Sessions
             var currentUser = await GetCurrentUserAsync();
             var currentTenant = await GetCurrentTenantAsync();
 
-            output.User.ShouldNotBe(null);
-            output.User.Name.ShouldBe(currentUser.Name);
+            output.User.Should().NotBeNull();
+            output.User.Name.Should().Be(currentUser.Name);
 
-            output.Tenant.ShouldNotBe(null);
-            output.Tenant.Name.ShouldBe(currentTenant.Name);
+            output.Tenant.Should().NotBeNull();
+            output.Tenant.Name.Should().Be(currentTenant.Name);
         }
     }
 }

--- a/aspnet-core/test/AbpCompanyName.AbpProjectName.Tests/Users/UserAppServiceTests.cs
+++ b/aspnet-core/test/AbpCompanyName.AbpProjectName.Tests/Users/UserAppServiceTests.cs
@@ -5,8 +5,8 @@
 using AbpCompanyName.AbpProjectName.Authorization.Users;
 using AbpCompanyName.AbpProjectName.Users;
 using AbpCompanyName.AbpProjectName.Users.Dto;
+using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
-using Shouldly;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -16,10 +16,8 @@ namespace AbpCompanyName.AbpProjectName.Tests.Users
     {
         private readonly IUserAppService _userAppService;
 
-        public UserAppServiceTests()
-        {
+        public UserAppServiceTests() =>
             _userAppService = Resolve<IUserAppService>();
-        }
 
         [Fact]
         public async Task GetUsers_Test()
@@ -28,7 +26,7 @@ namespace AbpCompanyName.AbpProjectName.Tests.Users
             var output = await _userAppService.GetAllAsync(new PagedUserResultRequestDto { MaxResultCount = 20, SkipCount = 0 });
 
             // Assert
-            output.Items.Count.ShouldBeGreaterThan(0);
+            output.Items.Count.Should().BeGreaterThan(0);
         }
 
         [Fact]
@@ -49,7 +47,7 @@ namespace AbpCompanyName.AbpProjectName.Tests.Users
             await UsingDbContextAsync(async context =>
             {
                 var johnNashUser = await context.Users.FirstOrDefaultAsync(u => u.UserName == "john.nash");
-                johnNashUser.ShouldNotBeNull();
+                johnNashUser.Should().NotBeNull();
             });
         }
     }

--- a/aspnet-core/test/AbpCompanyName.AbpProjectName.Web.Tests/AbpCompanyName.AbpProjectName.Web.Tests.csproj
+++ b/aspnet-core/test/AbpCompanyName.AbpProjectName.Web.Tests/AbpCompanyName.AbpProjectName.Web.Tests.csproj
@@ -18,12 +18,12 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="FluentAssertions" Version="6.11.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-      <PackageReference Include="NSubstitute" Version="5.0.0" />
-      <PackageReference Include="Shouldly" Version="4.2.1" />
-      <PackageReference Include="xunit" Version="2.4.2" />
-      <PackageReference Include="xunit.extensibility.execution" Version="2.4.2" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PackageReference Include="NSubstitute" Version="4.3.0" />
+      <PackageReference Include="xunit" Version="2.5.0" />
+      <PackageReference Include="xunit.extensibility.execution" Version="2.5.0" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       </PackageReference>

--- a/aspnet-core/test/AbpCompanyName.AbpProjectName.Web.Tests/AbpProjectNameWebTestBase.cs
+++ b/aspnet-core/test/AbpCompanyName.AbpProjectName.Web.Tests/AbpProjectNameWebTestBase.cs
@@ -13,10 +13,10 @@ using AbpCompanyName.AbpProjectName.Models.TokenAuth;
 using AbpCompanyName.AbpProjectName.Web.Startup;
 using AngleSharp.Html.Dom;
 using AngleSharp.Html.Parser;
+using FluentAssertions;
 using Microsoft.AspNetCore.Hosting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using Shouldly;
 using System;
 using System.Linq;
 using System.Net;
@@ -71,7 +71,7 @@ namespace AbpCompanyName.AbpProjectName.Web.Tests
             HttpStatusCode expectedStatusCode = HttpStatusCode.OK)
         {
             var response = await Client.GetAsync(url);
-            response.StatusCode.ShouldBe(expectedStatusCode);
+            response.StatusCode.Should().Be(expectedStatusCode);
             return response;
         }
 
@@ -99,7 +99,7 @@ namespace AbpCompanyName.AbpProjectName.Web.Tests
             var response = await Client.PostAsync(
                 "/api/TokenAuth/Authenticate",
                 new StringContent(input.ToJsonString(), Encoding.UTF8, "application/json"));
-            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
             var result =
                 JsonConvert.DeserializeObject<AjaxResponse<AuthenticateResultModel>>(
                     await response.Content.ReadAsStringAsync());

--- a/aspnet-core/test/AbpCompanyName.AbpProjectName.Web.Tests/Controllers/HomeControllerTests.cs
+++ b/aspnet-core/test/AbpCompanyName.AbpProjectName.Web.Tests/Controllers/HomeControllerTests.cs
@@ -5,7 +5,7 @@
 using AbpCompanyName.AbpProjectName.Authorization.Users;
 using AbpCompanyName.AbpProjectName.Models.TokenAuth;
 using AbpCompanyName.AbpProjectName.Web.Controllers;
-using Shouldly;
+using FluentAssertions;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -27,7 +27,7 @@ namespace AbpCompanyName.AbpProjectName.Web.Tests.Controllers
                 GetUrl<HomeController>(nameof(HomeController.Index)));
 
             // Assert
-            response.ShouldNotBeNullOrEmpty();
+            response.Should().NotBeNullOrEmpty();
         }
     }
 }


### PR DESCRIPTION
Swapped assertion nuget packages from Shouldly to FluentAssertions to be consistent with other projects.
Downgraded Castle.Core in Test Projects to fix breaking tests.
Upgraded XUnit packages to most recent stable.
Verified all tests passing locally

![image](https://github.com/Mesh-Systems-Eng/module-zero-core-template/assets/59617695/afdd0fd0-cdaf-42b7-93fd-8c1b52acb1c8)
