### PR TITLE
Default background worker timer to 5 minutes rather than 5 seconds

### DIFF
--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Core/Configuration/Options/ServiceCollectionExtension.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Core/Configuration/Options/ServiceCollectionExtension.cs
@@ -5,6 +5,7 @@
 using AbpCompanyName.AbpProjectName.Configuration.Options.Notifications;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace AbpCompanyName.AbpProjectName.Configuration.Options
 {
@@ -18,5 +19,23 @@ namespace AbpCompanyName.AbpProjectName.Configuration.Options
 
         public static IServiceCollection RegisterSmsConfiguration(this IServiceCollection services, IConfiguration configuration) =>
             services.Configure<SmsConfiguration>(configuration.GetSection("Notifications:SmsConfiguration"));
+
+        public static IServiceCollection ConfigureBackgroundWorkerTimer(this IServiceCollection services, IConfiguration configuration)
+        {
+            try
+            {
+                // A timer is set (in milliseconds) in the background to check for jobs to run by default every 5 seconds.
+                // Disabling this timer would cause the UserTokenExpirationWorker to not run.
+                var backgroundPollingPeriodInSeconds = configuration.GetValue<int>("BackgroundPollingPeriodInSeconds");
+                var backgroundPollingPeriodInMilliseconds = backgroundPollingPeriodInSeconds <= 0 ? 5000 : backgroundPollingPeriodInSeconds * 1000;
+                Abp.BackgroundJobs.BackgroundJobManager.JobPollPeriod = backgroundPollingPeriodInMilliseconds;
+            }
+            catch (Exception)
+            {
+                // intentionally ignoring on failure.
+            }
+
+            return services;
+        }
     }
 }

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Startup/Startup.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/Startup/Startup.cs
@@ -10,6 +10,7 @@ using Abp.Dependency;
 using Abp.Extensions;
 using Abp.Json;
 using AbpCompanyName.AbpProjectName.Configuration;
+using AbpCompanyName.AbpProjectName.Configuration.Options;
 using AbpCompanyName.AbpProjectName.Identity;
 using Castle.Facilities.Logging;
 using Microsoft.AspNetCore.Builder;
@@ -45,6 +46,8 @@ namespace AbpCompanyName.AbpProjectName.Web.Host.Startup
 
         public void ConfigureServices(IServiceCollection services)
         {
+            services.ConfigureBackgroundWorkerTimer(_appConfiguration);
+
             // MVC
             services.AddControllersWithViews(
                 options => { options.Filters.Add(new AbpAutoValidateAntiforgeryTokenAttribute()); })

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/appsettings.json
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Host/appsettings.json
@@ -1,28 +1,29 @@
 ﻿{
-  "ConnectionStrings": {
-    "Default": "Server=localhost; Database=AbpProjectNameDb; Trusted_Connection=True; TrustServerCertificate=True;"
-  },
-  "App": {
-    "ServerRootAddress": "https://localhost:44311/",
-    "ClientRootAddress": "http://localhost:4200/",
-    "CorsOrigins": "http://localhost:4200,http://localhost:8080,http://localhost:8081,http://localhost:3000"
-  },
-  "Authentication": {
-    "JwtBearer": {
-      "IsEnabled": "true",
-      "SecurityKey": "AbpProjectName_C421AAEE0D114E9C",
-      "Issuer": "AbpProjectName",
-      "Audience": "AbpProjectName"
-    }
-  },
-  "Kestrel": {
-    "Endpoints": {
-      "Http": {
-        "Url": "https://localhost:44311/"
-      }
-    }
-  },
-  "Swagger": {
-    "ShowSummaries": false
-  }
+    "ConnectionStrings": {
+        "Default": "Server=localhost; Database=AbpProjectNameDb; Trusted_Connection=True; TrustServerCertificate=True;"
+    },
+    "App": {
+        "ServerRootAddress": "https://localhost:44311/",
+        "ClientRootAddress": "http://localhost:4200/",
+        "CorsOrigins": "http://localhost:4200,http://localhost:8080,http://localhost:8081,http://localhost:3000"
+    },
+    "Authentication": {
+        "JwtBearer": {
+            "IsEnabled": "true",
+            "SecurityKey": "AbpProjectName_C421AAEE0D114E9C",
+            "Issuer": "AbpProjectName",
+            "Audience": "AbpProjectName"
+        }
+    },
+    "Kestrel": {
+        "Endpoints": {
+            "Http": {
+                "Url": "https://localhost:44311/"
+            }
+        }
+    },
+    "Swagger": {
+        "ShowSummaries": false
+    },
+    "BackgroundPollingPeriodInSeconds": 300
 }

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Startup/Startup.cs
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/Startup/Startup.cs
@@ -41,6 +41,8 @@ namespace AbpCompanyName.AbpProjectName.Web.Startup
 
         public void ConfigureServices(IServiceCollection services)
         {
+            services.ConfigureBackgroundWorkerTimer(_appConfiguration);
+
             // MVC
             services.AddControllersWithViews(
                     options =>

--- a/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/appsettings.json
+++ b/aspnet-core/src/AbpCompanyName.AbpProjectName.Web.Mvc/appsettings.json
@@ -35,5 +35,6 @@
         "SmsConfiguration": {
             "SubscriptionId": "<Add-Subscription-Id>"
         }
-    }
+    },
+    "BackgroundPollingPeriodInSeconds": 300
 }


### PR DESCRIPTION
Based on monitoring, a background job is firing by default every 5 seconds. Looking at the base libraries, a timer is set with 5000 milliseconds and exposed statically, that will be set to 5 minutes rather than seconds. This is configurable in the appsettings.json file under the _**BackgroundPollingPeriodInSeconds**_ property defaulting to 300 seconds (converted to milliseconds when setting the timer) aka 5 minutes. If there is no associated property in the appsettings.json, 5 seconds is the still the default for backwards compatibility.